### PR TITLE
Replace create_function with closure

### DIFF
--- a/src/PostSnippets/Shortcode.php
+++ b/src/PostSnippets/Shortcode.php
@@ -44,12 +44,12 @@ class Shortcode
                             $attributes["content"] = $content;
                         }
 
-                        $snippet = addslashes( $snippet["snippet"] );
+                        $snippettext = addslashes( $snippet["snippet"] );
                         // Disables auto conversion from & to &amp; as that should be done in snippet, not code (destroys php etc).
                         // $snippet = str_replace("&", "&amp;", $snippet);
 
                         foreach ( $attributes as $key => $val ) {
-                            $snippet = str_replace( '{' . $key . '}', $val, $snippet );
+                            $snippettext = str_replace( '{' . $key . '}', $val, $snippettext );
                         }
 
                         // There might be the case that a snippet contains
@@ -58,24 +58,24 @@ class Shortcode
                         // the shortcode is used without enclosing it. To
                         // avoid outputting {content} as part of the string
                         // lets remove possible occurences.
-                        $snippet = str_replace( '{content}', '', $snippet );
+                        $snippettext = str_replace( '{content}', '', $snippettext );
 
                         // Handle PHP shortcodes
                         $php = $snippet["php"];
                         if ( $php == true ) {
-                            $snippet = \PostSnippets\Shortcode::phpEval( $snippet );
+                            $snippettext = \PostSnippets\Shortcode::phpEval( $snippettext );
                         }
 
                         // Strip escaping and execute nested shortcodes
-                        $snippet = do_shortcode( stripslashes( $snippet ) );
+                        $snippettext = do_shortcode( stripslashes( $snippettext ) );
 
                         // WPTexturize the Snippet
                         $texturize = $texturize;
                         if ( $texturize == true ) {
-                            $snippet = wptexturize( $snippet );
+                            $snippettext = wptexturize( $snippettext );
                         }
 
-                        return $snippet;
+                        return $snippettext;
                     } );
                 }
             }

--- a/src/PostSnippets/Shortcode.php
+++ b/src/PostSnippets/Shortcode.php
@@ -33,54 +33,50 @@ class Shortcode
                     // Get the wptexturize setting
                     $texturize = isset($snippet["wptexturize"]) ? $snippet["wptexturize"] : false;
 
-                    add_shortcode(
-                        $snippet['title'],
-                        create_function(
-                            '$atts,$content=null',
-                            '$shortcode_symbols = array('.$vars_str.');
-                            extract(shortcode_atts($shortcode_symbols, $atts));
+                    add_shortcode( $snippet['title'], function ( $atts, $content = null ) use ( $vars_str, $snippet, $texturize ) {
+                        $shortcode_symbols = [ $vars_str ];
+                        extract( shortcode_atts( $shortcode_symbols, $atts ) );
 
-                            $attributes = compact( array_keys($shortcode_symbols) );
+                        $attributes = compact( array_keys( $shortcode_symbols ) );
 
-                            // Add enclosed content if available to the attributes array
-                            if ($content != null) {
-                                $attributes["content"] = $content;
-                            }
+                        // Add enclosed content if available to the attributes array
+                        if ( $content != null ) {
+                            $attributes["content"] = $content;
+                        }
 
-                            $snippet = \''. addslashes($snippet["snippet"]) .'\';
-                            // Disables auto conversion from & to &amp; as that should be done in snippet, not code (destroys php etc).
-                            // $snippet = str_replace("&", "&amp;", $snippet);
+                        $snippet = addslashes( $snippet["snippet"] );
+                        // Disables auto conversion from & to &amp; as that should be done in snippet, not code (destroys php etc).
+                        // $snippet = str_replace("&", "&amp;", $snippet);
 
-                            foreach ($attributes as $key => $val) {
-                                $snippet = str_replace("{".$key."}", $val, $snippet);
-                            }
+                        foreach ( $attributes as $key => $val ) {
+                            $snippet = str_replace( '{' . $key . '}', $val, $snippet );
+                        }
 
-                            // There might be the case that a snippet contains
-                            // the post snippets reserved variable {content} to
-                            // capture the content in enclosed shortcodes, but
-                            // the shortcode is used without enclosing it. To
-                            // avoid outputting {content} as part of the string
-                            // lets remove possible occurences.
-                            $snippet = str_replace("{content}", "", $snippet);
+                        // There might be the case that a snippet contains
+                        // the post snippets reserved variable {content} to
+                        // capture the content in enclosed shortcodes, but
+                        // the shortcode is used without enclosing it. To
+                        // avoid outputting {content} as part of the string
+                        // lets remove possible occurences.
+                        $snippet = str_replace( '{content}', '', $snippet );
 
-                            // Handle PHP shortcodes
-                            $php = "'. $snippet["php"] .'";
-                            if ($php == true) {
-                                $snippet = \PostSnippets\Shortcode::phpEval( $snippet );
-                            }
+                        // Handle PHP shortcodes
+                        $php = $snippet["php"];
+                        if ( $php == true ) {
+                            $snippet = \PostSnippets\Shortcode::phpEval( $snippet );
+                        }
 
-                            // Strip escaping and execute nested shortcodes
-                            $snippet = do_shortcode(stripslashes($snippet));
+                        // Strip escaping and execute nested shortcodes
+                        $snippet = do_shortcode( stripslashes( $snippet ) );
 
-                            // WPTexturize the Snippet
-                            $texturize = "'. $texturize .'";
-                            if ($texturize == true) {
-                                $snippet = wptexturize( $snippet );
-                            }
+                        // WPTexturize the Snippet
+                        $texturize = $texturize;
+                        if ( $texturize == true ) {
+                            $snippet = wptexturize( $snippet );
+                        }
 
-                            return $snippet;'
-                        )
-                    );
+                        return $snippet;
+                    } );
                 }
             }
         }


### PR DESCRIPTION
> PHP Deprecated:  Function create_function() is deprecated

The above deprecation warning is thrown on PHP 7.2.

Since PHP 5.3 at a minimum is required for this plugin there is no reason to not use a closure for this.

With #77 merged a new build should be triggered and testing can pass.