### PR TITLE
Add conditional code for checking if `dialog` and `tabs` functions exist

### DIFF
--- a/views/jquery_ui_dialog_head.php
+++ b/views/jquery_ui_dialog_head.php
@@ -19,79 +19,85 @@
             }
         }
         ?>
-    // We do the check to see if post snippets dialog is in the footer.
-    // Some plugins, like 'download monitor' uses WordPress admin bootstrap and
-    // then bring in admin_head but not admin_footer. So to allow other plugins
-    // to do that 'hack', we bail out in thoise cases.
-    if ($("#post-snippets-tabs").length>0) {
+        // We do the check to see if post snippets dialog is in the footer.
+        // Some plugins, like 'download monitor' uses WordPress admin bootstrap and
+        // then bring in admin_head but not admin_footer. So to allow other plugins
+        // to do that 'hack', we bail out in thoise cases.
+        if ($("#post-snippets-tabs").length>0) {
 
-        var tabs = $("#post-snippets-tabs").tabs();
+            if($.isFunction($().tabs)){ // Ensure the tabs function is available
+                var tabs = $("#post-snippets-tabs").tabs();
+            }
 
-        $(function() {
-            $("#post-snippets-dialog").dialog({
-                autoOpen: false,
-                modal: true,
-                dialogClass: 'wp-dialog',
-                buttons: {
-                    Cancel: function() {
-                        $(this).dialog("close");
-                    },
-                    "Insert": function() {
-                        $(this).dialog("close");
-                        <?php
-                        global $wp_version;
-                        if (version_compare($wp_version, '3.5', '<')) {
-                            ?>
-                            var selected = tabs.tabs('option', 'selected');
-                        <?php
+            $(function() {
 
-                        } else {
-                            ?>
-                            var selected = tabs.tabs('option', 'active');
-                        <?php
+                if($.isFunction($().dialog)){ // Ensure the dialog function is available
 
-                        }
-
-                        foreach ($snippets as $key => $snippet) {
-                            ?>
-                            if (selected == <?php echo $key;
-                            ?>) {
-                                insert_snippet = postsnippet_<?php echo $key;
-                            ?>;
+                    $("#post-snippets-dialog").dialog({
+                        autoOpen: false,
+                        modal: true,
+                        dialogClass: 'wp-dialog',
+                        buttons: {
+                            Cancel: function() {
+                                $(this).dialog("close");
+                            },
+                            "Insert": function() {
+                                $(this).dialog("close");
                                 <?php
-                                $var_arr = explode(",", $snippet['vars']);
-                            if (!empty($var_arr[0])) {
-                                foreach ($var_arr as $key_2 => $var) {
-                                    $varname = "var_" . $key . "_" . $key_2;
+                                global $wp_version;
+                                if (version_compare($wp_version, '3.5', '<')) {
                                     ?>
-                                        insert_snippet = insert_snippet.replace(/\{<?php echo $methods->stripDefaultVal($var);
-                                    ?>\}/g, <?php echo $varname;
-                                    ?>.val());
+                                    var selected = tabs.tabs('option', 'selected');
+                                <?php
+
+                                } else {
+                                    ?>
+                                    var selected = tabs.tabs('option', 'active');
                                 <?php
 
                                 }
+
+                                foreach ($snippets as $key => $snippet) {
+                                    ?>
+                                    if (selected == <?php echo $key;
+                                    ?>) {
+                                        insert_snippet = postsnippet_<?php echo $key;
+                                    ?>;
+                                        <?php
+                                        $var_arr = explode(",", $snippet['vars']);
+                                    if (!empty($var_arr[0])) {
+                                        foreach ($var_arr as $key_2 => $var) {
+                                            $varname = "var_" . $key . "_" . $key_2;
+                                            ?>
+                                                insert_snippet = insert_snippet.replace(/\{<?php echo $methods->stripDefaultVal($var);
+                                            ?>\}/g, <?php echo $varname;
+                                            ?>.val());
+                                        <?php
+
+                                        }
+                                    }
+                                    ?>
+                                }
+
+                            <?php
+
                             }
                             ?>
+
+                                // Decide what method to use to insert the snippet depending
+                                // from what editor the window was opened from
+                                if (post_snippets_caller == 'html') {
+                                    // HTML editor in WordPress 3.3 and greater
+                                    QTags.insertContent(insert_snippet);
+                                } else {
+                                    // Visual Editor
+                                    post_snippets_canvas.execCommand('mceInsertContent', false, insert_snippet);
+                                }
                             }
-
-                        <?php
-
-                        }
-                        ?>
-
-                            // Decide what method to use to insert the snippet depending
-                            // from what editor the window was opened from
-                            if (post_snippets_caller == 'html') {
-                                // HTML editor in WordPress 3.3 and greater
-                                QTags.insertContent(insert_snippet);
-                            } else {
-                                // Visual Editor
-                                post_snippets_canvas.execCommand('mceInsertContent', false, insert_snippet);
-                            }
-                        }
-                    },
-                    width: 500,
-                });
+                        },
+                        width: 500,
+                    });
+                }
             });
         }
     });


### PR DESCRIPTION
I had a site where dialog wasn't being loaded correctly due to a theme compatibility issue and this plugin tried calling a function that then didn't exist & resulted in a JavaScript error. As a precaution on this plugin's end, this makes sure the functions exist before trying to use them (preventing a potential JS error on the site admin).

Also, I reformatted the whitespace so indenting made more sense.